### PR TITLE
Set the GA account directly in the template

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -6,7 +6,7 @@
 <!-- User Analytics Code -->
 <script type="text/javascript">
   var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '{{ theme_analytics_id }}']);
+  _gaq.push(['_setAccount', 'UA-537692-22']);
   _gaq.push(['_trackPageview']);
 
   (function() {

--- a/source/conf.py
+++ b/source/conf.py
@@ -113,9 +113,7 @@ html_theme = 'sphinx_rtd_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    "analytics_id": "UA-537692-22",
-}
+#html_theme_options = { }
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]


### PR DESCRIPTION
For some reason the hieroglyph slides doesn't pull in the theme option for the GA code. As a workaround let's just directly set it in the template file and remove the option for the regular site.
